### PR TITLE
remove idporten acr validation

### DIFF
--- a/oasis/src/identity-providers/idporten.ts
+++ b/oasis/src/identity-providers/idporten.ts
@@ -1,4 +1,4 @@
-import { JWTVerifyResult, errors, jwtVerify } from "jose";
+import { JWTVerifyResult, jwtVerify } from "jose";
 import { SupportedRequestType, Token } from "../index";
 import { cachedRemoteJWKSet } from "../utils/cachedRemoteJWKSet";
 import { getTokenFromHeader } from "../utils/getTokenFromHeader";

--- a/oasis/src/identity-providers/idporten.ts
+++ b/oasis/src/identity-providers/idporten.ts
@@ -7,23 +7,10 @@ const idportenJWKSet = () =>
   cachedRemoteJWKSet(process.env.IDPORTEN_JWKS_URI as string);
 
 async function verify(token: string): Promise<JWTVerifyResult> {
-  const result = await jwtVerify(token, idportenJWKSet(), {
+  return jwtVerify(token, idportenJWKSet(), {
     issuer: process.env.IDPORTEN_ISSUER,
     audience: process.env.IDPORTEN_AUDIENCE,
   });
-
-  const acr = process.env.IDPORTEN_REQUIRED_ACR
-    ? [process.env.IDPORTEN_REQUIRED_ACR]
-    : ["Level4", "idporten-loa-high"];
-  // @ts-ignore
-  if (result.payload["acr"] in acr) {
-    throw new errors.JWTClaimValidationFailed(
-      `unexpected "acr" claim value, expected "${acr}", recieved"${result.payload["acr"]}"`,
-      "acr",
-      "check_failed"
-    );
-  }
-  return result;
 }
 
 export default async function idporten(


### PR DESCRIPTION
No longer needed according to the nais docs: https://docs.nais.io/security/auth/idporten/#security-levels