### PR TITLE
restrict return type of get token

### DIFF
--- a/oasis/src/get-token.ts
+++ b/oasis/src/get-token.ts
@@ -1,8 +1,12 @@
 import { IncomingMessage } from "http";
 
-export const getToken = (
+export function getToken(val: string): string;
+export function getToken(
+  val: Request | IncomingMessage | Headers,
+): string | null;
+export function getToken(
   val: Request | IncomingMessage | Headers | string,
-): string | null => {
+): string | null {
   if (typeof val === "string") {
     return val.startsWith("Bearer ") ? stripBearer(val) : val;
   } else if (val instanceof Headers) {
@@ -13,7 +17,7 @@ export const getToken = (
     const authHeader = val.headers.authorization;
     return authHeader ? stripBearer(authHeader) : null;
   }
-};
+}
 
 function getTokenFromHeaders(headers: Headers): string | null {
   const authHeader = headers.get("authorization");


### PR DESCRIPTION
Fjerner `null` fra returtypen til getToken om val er `string`.